### PR TITLE
refactor: fix intents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 require("dotenv").config();
 const { token, databaseToken } = process.env;
 const { connect } = require('mongoose');
-const { Client, Collection, GatewayIntentBits, GATEWAY_INTENTS } = require("discord.js");
+const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const fs = require("fs");
 
-const client = new Client({ intents: GatewayIntentBits.Guilds, GATEWAY_INTENTS });
+const client = new Client({ intents: [ GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent ] });
 client.commands = new Collection();
 client.commandArray = [];
 


### PR DESCRIPTION
`GATEWAY_INTENTS` does not exist on discord.js
In order to delete messages from a user after a ban, you need the messages intents to read them with the bot.